### PR TITLE
use correct framework

### DIFF
--- a/OrangeLoop.Sagas.Interfaces/OrangeLoop.Sagas.Interfaces.csproj
+++ b/OrangeLoop.Sagas.Interfaces/OrangeLoop.Sagas.Interfaces.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/OrangeLoop.Sagas.Tests/OrangeLoop.Sagas.Tests.csproj
+++ b/OrangeLoop.Sagas.Tests/OrangeLoop.Sagas.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/OrangeLoop.Sagas.UnitOfWork.SqlServer/OrangeLoop.Sagas.UnitOfWork.SqlServer.csproj
+++ b/OrangeLoop.Sagas.UnitOfWork.SqlServer/OrangeLoop.Sagas.UnitOfWork.SqlServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/OrangeLoop.Sagas/OrangeLoop.Sagas.csproj
+++ b/OrangeLoop.Sagas/OrangeLoop.Sagas.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Jared L. Stark</Authors>
     <Company>Orange Loop, LLC</Company>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > [!WARNING]
 > Version 2 of this package is a complete refactor and is **NOT** backwards compatible.
-> This version targets **net80** and has a much easier interface to work with than
+> This version targets **net8.0** and has a much easier interface to work with than
 > version 1.
 
 ## Installation

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: Visual Studio 2022
+
 version: 1.0.{build}
 
 build_script: dotnet build --configuration Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,5 @@
+version: 1.0.{build}
+
+build_script: dotnet build --configuration Release
+
+test_script: dotnet test --configuration Release --no-build --verbosity normal


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)